### PR TITLE
Decouple from Laravel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ gen
 composer.phar
 composer.lock
 /vendor/
+*.cache
+*.bak

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
   },
   "require": {
     "php": "^7.4",
-    "ext-curl": "*",
-    "laravel/framework": "7.*"
+    "ext-curl": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.2",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,25 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="DB_CONNECTION" value="testing"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
Allow upgrading to Laravel 8.0 by removing the explicit dependency on Laravel `7.*`.